### PR TITLE
Switch to Entware-ng feed

### DIFF
--- a/gateway/others/ipkg.conf
+++ b/gateway/others/ipkg.conf
@@ -1,4 +1,4 @@
-src entware http://entware.wl500g.info/binaries/entware
+src entware-ng http://entware.zyxmon.org/binaries/mipsel
 #src optware http://ipkg.nslu2-linux.org/feeds/optware/oleg/cross/stable
 
 dest root /


### PR DESCRIPTION
Entware is deprecated since October 2015. 

https://github.com/Entware/entware/#note