### PR TITLE
ipkg.conf.entware-ng: New domain

### DIFF
--- a/gateway/others/ipkg.conf.entware
+++ b/gateway/others/ipkg.conf.entware
@@ -1,2 +1,3 @@
 src entware http://entware.wl500g.info/binaries/entware
+
 dest root /

--- a/gateway/others/ipkg.conf.entware-ng
+++ b/gateway/others/ipkg.conf.entware-ng
@@ -1,3 +1,3 @@
-src entware-ng http://entware.zyxmon.org/binaries/mipsel
+src entware-ng http://pkg.entware.net/binaries/mipsel
 
 dest root /


### PR DESCRIPTION
The old installations will continue to work with previous URL without any problems.

The new ones will use `entware.net` domain.
