### PR TITLE
Update MIPS R1 Entware feed URL

### DIFF
--- a/gateway/others/ipkg.conf.entware
+++ b/gateway/others/ipkg.conf.entware
@@ -1,3 +1,3 @@
-src entware http://entware.wl500g.info/binaries/entware
+src entware http://old.entware.net/binaries/entware
 
 dest root /


### PR DESCRIPTION
All Entware(-ng) feeds are on it's own domains.
